### PR TITLE
Fix nullref on visitors with no acceptors

### DIFF
--- a/VisitorPatternGenerator/VisitorPatternGenerator.cs
+++ b/VisitorPatternGenerator/VisitorPatternGenerator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -82,6 +81,11 @@ public class VisitorPatternGenerator: IIncrementalGenerator
             context.RegisterSourceOutput(visitorProvider, static (ctx, e) => {
                 var ((visitor, acceptors), rootNamespace) = e;
                 ctx.CancellationToken.ThrowIfCancellationRequested();
+
+                if (acceptors.IsDefaultOrEmpty) {
+                    return;
+                }
+
                 _AddVisitorSource(ctx, rootNamespace, visitor, acceptors);
             });
         }


### PR DESCRIPTION
When a visitor has no acceptors, a nullref with crash the generator, failing to generate source across the entire project.

This PR fixes the issue by simply not generating any source for the visitors that have no acceptors. As I believe, it does not hurt to just ignore the visitors and keep them there, without any acceptor implementations, unless explicitly defined as the model suggests.

I tested this by adding some tests and basically building the test project to contain unit tests ready for execution, using NUnit. It has been opened as a separate PR: #2.